### PR TITLE
Add result recording and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Run benchmark:
 python run_benchmark.py --model_name=gpt-4o --dataset_path=simple_bench_public.json
 ```
 
+After running benchmarks for each model, a CSV file will be written to the
+`results/` directory containing the score and whether each answer was correct.
+To generate a performance graph from these CSV files run:
+
+```
+python analyze_results.py
+```
+
 ## Setup Instructions
 
 Clone the github repo and cd into it.

--- a/analyze_results.py
+++ b/analyze_results.py
@@ -1,0 +1,40 @@
+import glob
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def analyze_results(results_dir: str = "results", output_file: str = "performance.png"):
+    pattern = os.path.join(results_dir, "results_*.csv")
+    result_files = glob.glob(pattern)
+    if not result_files:
+        print("No result files found.")
+        return
+
+    models = []
+    num_correct = []
+    scores = []
+    for path in result_files:
+        model_name = os.path.splitext(os.path.basename(path))[0].split("results_")[1]
+        data = np.genfromtxt(path, delimiter=",", names=True, dtype=None, encoding="utf-8")
+        models.append(model_name)
+        num_correct.append(np.sum(data["correct"]))
+        scores.append(np.sum(data["score"]))
+
+    x = np.arange(len(models))
+    fig, ax1 = plt.subplots()
+    ax1.bar(x - 0.2, num_correct, width=0.4, color="tab:blue", label="Number Correct")
+    ax1.set_ylabel("Number Correct", color="tab:blue")
+    ax2 = ax1.twinx()
+    ax2.bar(x + 0.2, scores, width=0.4, color="tab:orange", label="Total Score")
+    ax2.set_ylabel("Total Score", color="tab:orange")
+    ax1.set_xticks(x)
+    ax1.set_xticklabels(models, rotation=45, ha="right")
+    plt.title("AI Performance")
+    fig.tight_layout()
+    plt.savefig(output_file)
+    print(f"Saved performance graph to {output_file}")
+
+
+if __name__ == "__main__":
+    analyze_results()


### PR DESCRIPTION
## Summary
- extend `run_benchmark.py` to record per-question results in CSV
- add `analyze_results.py` to aggregate results using NumPy and create a graph
- update README with instructions

## Testing
- `python -m py_compile run_benchmark.py analyze_results.py weave_utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684f0aba3ed0832390665a4ecf15b5f6