### PR TITLE
Run benchmark for each OpenAI model

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -1,10 +1,11 @@
 # python run_benchmark.py --model_name=gpt-4o-mini --dataset_path=output.json
 
-from typing import Optional
+from typing import Optional, List
 import json
 import weave
 import asyncio
 from fire import Fire
+import openai
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -17,6 +18,17 @@ def load_dataset(file_path):
     with open(file_path, 'r') as file:
         data = json.load(file)
         return data['eval_data']
+
+
+def get_openai_models() -> List[str]:
+    """Fetch available model names from the OpenAI API."""
+    try:
+        client = openai.OpenAI()
+        response = client.models.list()
+        return [model.id for model in response.data]
+    except Exception as exc:
+        print(f"Failed to fetch OpenAI models: {exc}")
+        return []
 
 
 def run_benchmark(
@@ -98,8 +110,53 @@ def run_benchmark(
     if num_responses > 1:
         model = MajorityVoteModel(model=model, num_responses=num_responses)
 
-    asyncio.run(evaluation.evaluate(model))
+    result = asyncio.run(evaluation.evaluate(model))
+    return result
+
+
+def run_all_benchmarks(
+    dataset_path: str = "simple_bench_public.json",
+    num_responses: int = 1,
+    entity: str = "simplebench",
+    project: str = "simple_bench_public",
+    temp: float = 0.7,
+    max_tokens: int = 2048,
+    top_p: float = 0.95,
+    max_retries: int = 3,
+    confidence: Optional[bool] = False,
+    system_prompt_path: str = "system_prompt.txt",
+    repeats: int = 3,
+) -> None:
+    """Run benchmarks for all available OpenAI models."""
+    models = get_openai_models()
+    all_results = []
+    for model_name in models:
+        for idx in range(repeats):
+            res = run_benchmark(
+                model_name=model_name,
+                dataset_path=dataset_path,
+                num_responses=num_responses,
+                entity=entity,
+                project=project,
+                temp=temp,
+                max_tokens=max_tokens,
+                top_p=top_p,
+                max_retries=max_retries,
+                confidence=confidence,
+                system_prompt_path=system_prompt_path,
+            )
+            all_results.append({
+                "model_name": model_name,
+                "run_index": idx + 1,
+                "result": res,
+            })
+
+    with open("benchmark_results.json", "w") as f:
+        json.dump(all_results, f, indent=2, default=str)
 
 
 if __name__ == "__main__":
-    Fire(run_benchmark)
+    Fire({
+        "run_benchmark": run_benchmark,
+        "run_all_benchmarks": run_all_benchmarks,
+    })


### PR DESCRIPTION
## Summary
- fetch available model names from OpenAI
- iterate over every model and run benchmark 3 times each
- save model name along with results to `benchmark_results.json`
- expose new `run_all_benchmarks` command via Fire

## Testing
- `python -m py_compile run_benchmark.py`

------
https://chatgpt.com/codex/tasks/task_e_684f116da8548323845635a9c58e9054